### PR TITLE
課題10 crud処理のデータの更新・削除＋例外処理を追加

### DIFF
--- a/src/main/java/com/example/javafinalchallenge/application/controller/UserController.java
+++ b/src/main/java/com/example/javafinalchallenge/application/controller/UserController.java
@@ -5,7 +5,9 @@ import com.example.javafinalchallenge.domain.service.UserService;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,4 +40,15 @@ public class UserController {
     return ResponseEntity.ok("登録完了しました。");
   }
 
+  @PatchMapping
+  public ResponseEntity<String> update(@RequestBody @Validated User user) {
+    userService.updateUser(user);
+    return ResponseEntity.ok("更新完了しました。");
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<String> delete(@PathVariable("id") int id) {
+    userService.deleteById(id);
+    return ResponseEntity.ok("削除完了しました。");
+  }
 }

--- a/src/main/java/com/example/javafinalchallenge/domain/service/UserService.java
+++ b/src/main/java/com/example/javafinalchallenge/domain/service/UserService.java
@@ -11,4 +11,8 @@ public interface UserService {
   User findId(int id);
 
   void createUser(User user);
+
+  void updateUser(User user);
+
+  void deleteById(int id);
 }

--- a/src/main/java/com/example/javafinalchallenge/domain/service/UserServiceImpl.java
+++ b/src/main/java/com/example/javafinalchallenge/domain/service/UserServiceImpl.java
@@ -32,4 +32,16 @@ public class UserServiceImpl implements UserService {
   public void createUser(User user) {
     userMapper.createUser(user);
   }
+
+  @Override
+  public void updateUser(User user) {
+    userMapper.updateUser(user);
+  }
+
+  @Override
+  public void deleteById(int id) {
+    userMapper.count(id)
+        .orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+    userMapper.deleteById(id);
+  }
 }

--- a/src/main/java/com/example/javafinalchallenge/infrastructure/UserMapper.java
+++ b/src/main/java/com/example/javafinalchallenge/infrastructure/UserMapper.java
@@ -3,9 +3,11 @@ package com.example.javafinalchallenge.infrastructure;
 import com.example.javafinalchallenge.domain.model.User;
 import java.util.List;
 import java.util.Optional;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 
 @Mapper
@@ -20,4 +22,9 @@ public interface UserMapper {
   @Insert("insert into users (name, email) values (#{name}, #{email})")
   void createUser(User user);
 
+  @Update("update users set name=#{name},email=#{email} where id=#{id}")
+  void updateUser(User user);
+
+  @Delete("delete from users where id = #{id}")
+  void deleteById(int id);
 }


### PR DESCRIPTION
# 概要
crud処理のデータの更新・削除＋例外処理を実装しました。
レビューお願いいたします。

# やったこと

* ①データの更新の実装結果
* ②例外処理(データ更新時に空欄とメースアドレスが正式な形でない時バリデーション処理をする)+実装結果
* ③データの削除の実装結果
* ④例外処理(削除したidが存在しない場合、404やエラーメッセージを返す)+実装結果

## ①データの更新の実装結果

<h2> 更新前

<img width="1440" alt="スクリーンショット 2022-10-13 23 26 11" src="https://user-images.githubusercontent.com/90845405/195634507-e82b57a1-cf86-458e-804f-c5b7922a6504.png">

<h2>更新

<img width="1440" alt="スクリーンショット 2022-10-13 23 26 57" src="https://user-images.githubusercontent.com/90845405/195634785-0db42435-3223-4a52-b67d-6be6a28bb717.png">

<h2>更新されたか確認

<img width="1440" alt="スクリーンショット 2022-10-13 23 27 07" src="https://user-images.githubusercontent.com/90845405/195634929-0e986ac6-3f0e-430c-b5e9-de1f60ace604.png">

## ②例外処理(データ更新時に空欄とメースアドレスが正式な形でない時バリデーション処理をする)

<h2>データ更新時に空欄でリクエストするとバリデーション処理する

<img width="1440" alt="スクリーンショット 2022-10-13 23 28 44" src="https://user-images.githubusercontent.com/90845405/195635454-77f27917-3697-4bb5-ab47-dd7a6eac7b51.png">

<h2>データ更新時にメースアドレスが正式な形でない場合バリデーション処理する

<img width="1440" alt="スクリーンショット 2022-10-13 23 29 36" src="https://user-images.githubusercontent.com/90845405/195635804-d96ad925-bdad-4425-81a2-137f71c56a4f.png">

##  ③データの削除の実装結果

<h2>削除

<img width="1440" alt="スクリーンショット 2022-10-13 23 27 29" src="https://user-images.githubusercontent.com/90845405/195636364-70c6c53e-e6a3-4a63-b89d-d676fa49257c.png">

<h2>削除されているか確認
<img width="1440" alt="スクリーンショット 2022-10-13 23 27 42" src="https://user-images.githubusercontent.com/90845405/195636531-73b9aac0-bcf3-4e03-bbd1-f5173ddba340.png">

## ④例外処理(削除したidが存在しない場合、404やエラーメッセージを返す)+実装結果

<img width="1440" alt="スクリーンショット 2022-10-13 23 27 53" src="https://user-images.githubusercontent.com/90845405/195636764-eda32081-e3ec-4ff6-a952-accd6a9cb929.png">



